### PR TITLE
Adding a limit to the depth of the component hierarchy that is scanned and thus displayed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ Once it is installed, you can run it by passing in the path to the source of the
 
 ```
 $ rch
+Usage: rch [opts] <path/to/rootComponent>
 
-  Usage: rch [opts] <path/to/rootComponent>
+React component hierarchy viewer.
 
-  React component hierarchy viewer.
+Options:
+  -V, --version             output the version number
+  -m, --module-dir <dir>    Path to additional modules not included in node_modules e.g. src
+  -c, --hide-containers     Hide redux container components
+  -t, --hide-third-party    Hide third party components
+  -d, --scan-depth <depth>  Limit the depth of the component hierarchy that is displayed
+  -h, --help                output usage information
 
-  Options:
-
-    -h, --help              output usage information
-    -V, --version           output the version number
-    -m, --module-dir <dir>  Path to additional modules not included in node_modules e.g. src
-    -c, --hide-containers   Hide redux container components
-    -t, --hide-third-party  Hide third party components
 ```
 
 ## Requirements

--- a/bin/rch.js
+++ b/bin/rch.js
@@ -17,6 +17,7 @@ program
   )
   .option('-c, --hide-containers', 'Hide redux container components')
   .option('-t, --hide-third-party', 'Hide third party components')
+  .option('-d, --scan-depth <depth>', 'Limit the depth of the component hierarchy that is displayed', parseInt)
   .description('React component hierarchy viewer.')
   .parse(process.argv);
 
@@ -27,6 +28,7 @@ if (!program.args[0]) {
 const hideContainers = program.hideContainers;
 const moduleDir = program.moduleDir;
 const hideThirdParty = program.hideThirdParty;
+const scanDepth = Math.max(program.scanDepth,1);
 
 const filename = path.resolve(program.args[0]);
 
@@ -277,7 +279,9 @@ function processNode(node, depth, parent) {
     node.filename = name;
     try {
       const file = readFileSync(node.filename, 'utf8');
-      processFile(node, file, depth);
+      if(depth <= scanDepth){
+        processFile(node, file, depth);
+      }
       node.children.forEach(c => processNode(c, depth + 1, node));
       return;
     } catch (e) {}


### PR DESCRIPTION
## Description of Pull Request
A new option was added to limit the scanning depth of the component hierarchy

## Test Case (Optional)
Scann a project and use the new -d option with a number that is lower than the depth of the projects depth

