### PR TITLE
Use @babel/parser instead of babylon

### DIFF
--- a/bin/rch.js
+++ b/bin/rch.js
@@ -3,7 +3,7 @@
 'use strict'; // eslint-disable-line
 const program = require('commander');
 const path = require('path');
-const babylon = require('babylon');
+const babelParser = require('@babel/parser');
 const readFileSync = require('fs').readFileSync;
 const _ = require('lodash');
 const tree = require('pretty-tree');
@@ -158,15 +158,16 @@ function findContainerChild(node, body, imports, depth) {
 }
 
 function processFile(node, file, depth) {
-  const ast = babylon.parse(file, {
+  const ast = babelParser.parse(file, {
     sourceType: 'module',
+    tokens: true,
     plugins: [
       'asyncGenerators',
       'classProperties',
-      'classProperties',
-      'decorators',
+      'decorators-legacy',
       'dynamicImport',
-      'exportExtensions',
+      'exportDefaultFrom',
+      'exportNamespaceFrom',
       'flow',
       'functionBind',
       'functionSent',

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tool"
   ],
   "dependencies": {
-    "babylon": "^6.8.0",
+    "@babel/parser": "^7.16.0",
     "commander": "^2.9.0",
     "lodash": "^4.13.1",
     "pretty-tree": "surreal9/pretty-tree"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@babel/parser@^7.16.0":
+  version "7.17.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.8.tgz#2817fb9d885dd8132ea0f8eb615a6388cca1c240"
+  integrity sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==
+
 ansi-regex@^1.0.0, ansi-regex@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-1.1.1.tgz#41c847194646375e6a1a5d10c3ca054ef9fc980d"
@@ -13,10 +18,6 @@ ansi-styles@^2.0.1:
 archy@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/archy/-/archy-0.0.2.tgz#910f43bf66141fc335564597abc189df44b3d35e"
-
-babylon@^6.8.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 chalk@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description of Pull Request
Turns out babylon is deprecated, so in order to support newer language features, e.g. optional chaining, I moved to babylon's successor, @babel/parser. Some plugins have changed, but it should be functionally the same as before now.

## Test Case (Optional)
A simple test case I've used:

```
cat > foo.jsx << EOF
import React from "react";
import Bar from "./bar.jsx";

export default function Foo() {
    console.log(undefined ?? "Undefined is not defined");
    return (
        <div class="foo">
            <Bar />
        </div>
    );
}
EOF
cat > bar.jsx << EOF
import React from "react";

export default Bar = () => <div class="bar">Hello, World!</div>;
EOF
node bin/rch.js foo.jsx
```

### Current behaviour:

Fails silently without error message, unless the `console.log` line in `foo.jsx` is removed.

### Expected behaviour:

This output:

```
foo
└── bar.jsx/Bar
```

## Reviewer(s)
(Nor sure who to add here)
