### PR TITLE
Show parsing errors

### DIFF
--- a/bin/rch.js
+++ b/bin/rch.js
@@ -17,6 +17,7 @@ program
   )
   .option('-c, --hide-containers', 'Hide redux container components')
   .option('-t, --hide-third-party', 'Hide third party components')
+  .option('-e, --show-parsing-errors', 'Show parsing errors')
   .description('React component hierarchy viewer.')
   .parse(process.argv);
 
@@ -27,6 +28,7 @@ if (!program.args[0]) {
 const hideContainers = program.hideContainers;
 const moduleDir = program.moduleDir;
 const hideThirdParty = program.hideThirdParty;
+const showParsingErrors = program.showParsingErrors;
 
 const filename = path.resolve(program.args[0]);
 
@@ -277,7 +279,14 @@ function processNode(node, depth, parent) {
     node.filename = name;
     try {
       const file = readFileSync(node.filename, 'utf8');
-      processFile(node, file, depth);
+      try {
+        processFile(node, file, depth);
+      } catch (e) {
+        if (showParsingErrors) {
+          console.error(e);
+        }
+        continue;
+      }
       node.children.forEach(c => processNode(c, depth + 1, node));
       return;
     } catch (e) {}


### PR DESCRIPTION
## Description of Pull Request
I found this quite useful for debugging, but I suppose the errors were being swallowed for a reason, so it's behind an option.

## Test Case (Optional)
Before and after this change, the following will simply output nothing:
```
echo '?' > invalid.jsx
node bin/rch.js invalid.jsx
```

But after this change, running `node bin/rch.js -e invalid.jsx` will show the actual parsing error.

## Reviewer(s)
(Not sure who to add here)